### PR TITLE
chore: add test-p script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"author": "Taskworld Inc.",
 	"scripts": {
-		"test": "nodemon index.ts"
+		"test": "nodemon index.ts",
+		"test-p": "nodemon index.ts -p"
 	},
 	"license": "ISC",
 	"devDependencies": {


### PR DESCRIPTION
Sometimes, during the interviewing many interviewers don't know why `-p` option doesn't work when they let candidate runs the `test` script with `-p` option. this situation happens when candidate uses `npm` because when using npm we have to type `npm run test -- -p` to make the `-p` option works. for yarn, we can use `yarn test -p`. so, I would like to add one more script for running the test script with `-p` option regardless of yarn or npm.